### PR TITLE
Add directory check as per http://www.emacswiki.org/emacs/GnusAlias

### DIFF
--- a/gnus-alias.el
+++ b/gnus-alias.el
@@ -1166,7 +1166,8 @@ If none of the above, return \"\"."
      ;; .........................
      ;; FILE
      ((and (> (length element) 0)
-           (file-exists-p element))
+           (and (file-exists-p element)
+                (not (file-directory-p element))))
       (with-temp-buffer
         (insert-file-contents element nil)
         (buffer-string)))


### PR DESCRIPTION
Hi,

I've made a pull request for the Fcc-related patch by  Geoff Ferrari that was posted at http://www.emacswiki.org/emacs/GnusAlias.  Basically, this tells it not to try to read a directory as a file, from what I understand.
